### PR TITLE
Fix parameter problems

### DIFF
--- a/pkg/impl/libraptorq/decoder.go
+++ b/pkg/impl/libraptorq/decoder.go
@@ -13,7 +13,7 @@ type DecoderFactory struct {
 func (*DecoderFactory) New(commonOTI uint64, schemeSpecificOTI uint32) (
 	decoder raptorq.Decoder, err error) {
 	wrapped := swig.NewBytesDecoder(swig.HostToNet64(commonOTI),
-		swig.HostToNet32(uint(schemeSpecificOTI)))
+		swig.HostToNet32(schemeSpecificOTI))
 	if wrapped.Initialized() {
 		decoder = &Decoder{wrapped, commonOTI, schemeSpecificOTI}
 		runtime.SetFinalizer(decoder, finalizeDecoder)

--- a/pkg/impl/libraptorq/encoder.go
+++ b/pkg/impl/libraptorq/encoder.go
@@ -12,7 +12,7 @@ type EncoderFactory struct {
 
 func (*EncoderFactory) New(input []byte, symbolSize uint16, minSubSymbolSize uint16,
 	maxSubBlockSize uint32, alignment uint8) (enc raptorq.Encoder, err error) {
-	wrapped := swig.NewBytesEncoder(input, minSubSymbolSize, symbolSize,
+	wrapped := swig.InitBytesEncoder(input, minSubSymbolSize, symbolSize,
 		int64(maxSubBlockSize))
 	if !wrapped.Initialized() {
 		swig.DeleteBytesEncoder(wrapped)

--- a/pkg/impl/libraptorq/encoder.go
+++ b/pkg/impl/libraptorq/encoder.go
@@ -74,6 +74,9 @@ func (enc *Encoder) Encode(sbn uint8, esi uint32, buf []byte) (written uint, err
 		err = errors.New("RaptorQ encoder buffer too small")
 	} else {
 		written = uint(enc.wrapped.Encode(buf, esi, sbn))
+		if written == 0 {
+			err = errors.New("RaptorQ encoder returned an error indication")
+		}
 	}
 	return
 }

--- a/pkg/impl/libraptorq/swig/stdint.swg
+++ b/pkg/impl/libraptorq/swig/stdint.swg
@@ -1,12 +1,26 @@
 %{
 #include <stdint.h>
+#include <cstdint>
 %}
 
-typedef unsigned char uint8_t;
-typedef signed char int8_t;
-typedef unsigned short uint16_t;
-typedef signed short int16_t;
-typedef unsigned int uint32_t;
-typedef signed int int32_t;
-typedef unsigned long uint64_t;
-typedef signed long int64_t;
+%include "stdint.i"
+
+namespace std {
+	using uint8_t = ::uint8_t;
+	using int8_t = ::int8_t;
+	using uint16_t = ::uint16_t;
+	using int16_t = ::int16_t;
+	using uint32_t = ::uint32_t;
+	using int32_t = ::int32_t;
+	using uint64_t = ::uint64_t;
+	using int64_t = ::int64_t;
+}
+
+%typemap(gotype) uint8_t, uint8_t const, uint8_t const &, std::uint8_t, std::uint8_t const, std::uint8_t const & "uint8"
+%typemap(gotype) int8_t, int8_t const, int8_t const &, std::int8_t, std::int8_t const, std::int8_t const & "int8"
+%typemap(gotype) uint16_t, uint16_t const, uint16_t const &, std::uint16_t, std::uint16_t const, std::uint16_t const & "uint16"
+%typemap(gotype) int16_t, int16_t const, int16_t const &, std::int16_t, std::int16_t const, std::int16_t const & "int16"
+%typemap(gotype) uint32_t, uint32_t const, uint32_t const &, std::uint32_t, std::uint32_t const, std::uint32_t const & "uint32"
+%typemap(gotype) int32_t, int32_t const, int32_t const &, std::int32_t, std::int32_t const, std::int32_t const & "int32"
+%typemap(gotype) uint64_t, uint64_t const, uint64_t const &, std::uint64_t, std::uint64_t const, std::uint64_t const & "uint64"
+%typemap(gotype) int64_t, int64_t const, int64_t const &, std::int64_t, std::int64_t const, std::int64_t const & "int64"

--- a/pkg/impl/libraptorq/swig/swig.swigcxx
+++ b/pkg/impl/libraptorq/swig/swig.swigcxx
@@ -728,23 +728,27 @@ bool set_compression(Compress const compression);
 size_t local_cache_size (size_t const local_cache);
 size_t get_local_cache_size();
 
-namespace Impl {
-namespace Endian {
-
-template <typename T> constexpr T b_to_h(T const b);
-template <typename T> constexpr T h_to_b(T const h);
-
-%template(NetToHost16) b_to_h<uint16_t>;
-%template(NetToHost32) b_to_h<uint32_t>;
-%template(NetToHost64) b_to_h<uint64_t>;
-
-%template(HostToNet16) h_to_b<uint16_t>;
-%template(HostToNet32) h_to_b<uint32_t>;
-%template(HostToNet64) h_to_b<uint64_t>;
-
-} // namespace Endian
-} // namespace Impl
 } // namespace RaptorQ__v1
+
+%define NET_TO_HOST_TO_NET(size)
+%inline %{
+
+constexpr uint##size##_t NetToHost##size(uint##size##_t const b) {
+    return RaptorQ__v1::Impl::Endian::b_to_h(b);
+}
+
+constexpr uint##size##_t HostToNet##size(uint##size##_t const h) {
+    return RaptorQ__v1::Impl::Endian::h_to_b(h);
+}
+
+%}
+%enddef
+
+NET_TO_HOST_TO_NET(16)
+NET_TO_HOST_TO_NET(32)
+NET_TO_HOST_TO_NET(64)
+
+#undef NET_TO_HOST_TO_NET
 
 namespace RFC6330__v1 {
 

--- a/pkg/impl/libraptorq/swig/swig.swigcxx
+++ b/pkg/impl/libraptorq/swig/swig.swigcxx
@@ -1094,3 +1094,20 @@ public:
 
 %template(BytesEncoder) RFC6330__v1::Impl::Encoder<unsigned char *, unsigned char *>;
 %template(BytesDecoder) RFC6330__v1::Impl::Decoder<unsigned char *, unsigned char *>;
+
+%inline %{
+
+typedef RFC6330__v1::Impl::Encoder<unsigned char *, unsigned char *> BytesEncoder;
+
+BytesEncoder *InitBytesEncoder(
+    unsigned char *SLICEBEGIN, unsigned char *SLICEEND,
+    uint16_t min_subsymbol_size, uint16_t symbol_size, size_t max_sub_block
+) {
+    auto enc = new BytesEncoder(
+        SLICEBEGIN, SLICEEND, min_subsymbol_size, symbol_size, max_sub_block
+    );
+    enc->compute(RaptorQ__v1::Compute::COMPLETE | RaptorQ__v1::Compute::NO_BACKGROUND);
+    return enc;
+}
+
+%}


### PR DESCRIPTION
This fixes the libRaptorQ zero-as-error return issue.  Essentially, `enc->compute(…)` needed to be called in advance to prime the matrices, as the RFC version of the API does not create the per-source-block encoder on demand.

This patch also converts zero value returned by `enc->encode(…)` into a proper error, and properly handles explicitly-sized integer conversions between C++ and Go.