### PR TITLE
Decoder Close() method causes panic - fix

### DIFF
--- a/internal/impl/libraptorq/decoder.go
+++ b/internal/impl/libraptorq/decoder.go
@@ -82,7 +82,7 @@ func (dec *Decoder) readyBlocksLoop() {
 		case swig.Error_NONE:
 			dec.rbcs.AddBlock(sbn)
 		case swig.Error_EXITING:
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
I finally realize the reason I get panic from Decoder's Close() method, which I described [here](https://github.com/harmony-one/go-raptorq/issues/6). This small fix Is based also on comments from the original code:
`
// 8. The future in a WaitForBlock() call (made from readyBlocksLoop()) returns
//    Error::EXITING.
// 9. readyBlocksLoop() sees Error::EXITING and breaks out of loop.
//
// Note that by the time readyBlocksLoop() sees Error::EXITING,
// the “wrapped” field has already been reset as nil.
`
So, there was just a small typo in the original code, which break a lot. Kindly check.